### PR TITLE
kernel: thread context.Context into hook contexts

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -148,9 +148,10 @@ Turn Start
 
 ```go
 type TurnContext struct {
-    AgentCtx *AgentContext // live conversation state; mutate to alter behavior
-    Input    string        // the original user message passed to Run()
-    Result   *Result       // nil in OnStart; populated in OnFinish
+    Ctx      context.Context // active ctx from Run/Stream — see "Ctx field" below
+    AgentCtx *AgentContext   // live conversation state; mutate to alter behavior
+    Input    string          // the original user message passed to Run()
+    Result   *Result         // nil in OnStart; populated in OnFinish
 }
 ```
 
@@ -158,9 +159,10 @@ type TurnContext struct {
 
 ```go
 type RoundContext struct {
-    AgentCtx     *AgentContext // live conversation state
-    RoundNumber  int           // 0-based index of the current round
-    LastResponse *Response     // nil in round 0; the previous LLM response otherwise
+    Ctx          context.Context // active ctx from Run/Stream — see "Ctx field" below
+    AgentCtx     *AgentContext   // live conversation state
+    RoundNumber  int             // 0-based index of the current round
+    LastResponse *Response       // nil in round 0; the previous LLM response otherwise
 }
 ```
 
@@ -168,6 +170,7 @@ type RoundContext struct {
 
 ```go
 type ToolContext struct {
+    Ctx      context.Context // active ctx from Run/Stream — see "Ctx field" below
     ToolName string          // name of the tool being called
     Params   json.RawMessage // raw JSON params from the model
     Result   any             // nil in OnToolStart; populated in OnToolEnd
@@ -175,20 +178,53 @@ type ToolContext struct {
 }
 ```
 
+#### The `Ctx` field
+
+Every hook context carries `Ctx`, the same `context.Context` you passed to
+`Agent.Run` (or `Agent.Stream`). The kernel populates `Ctx` immediately before
+firing each hook, so it is always non-nil and reflects the live request scope.
+
+Use `Ctx` to:
+
+- **Tracing**: open an OTel child span from inside a hook
+  (`tracer.Start(tc.Ctx, "agent.tool")`) and have it nest under the caller's
+  span automatically.
+- **Cancellation**: long-running hook work can return early via
+  `select { case <-rc.Ctx.Done(): ... }` or check `rc.Ctx.Err()` to react to
+  upstream cancellation/deadline expiry.
+- **Request-scoped values**: read values stashed by upstream middleware
+  (request IDs, auth principals, tenant info) with `tc.Ctx.Value(myKey)`.
+
+```go
+kernel.OnToolStart(func(tc *kernel.ToolContext) {
+    ctx, span := tracer.Start(tc.Ctx, "tool."+tc.ToolName)
+    span.SetAttributes(attribute.String("params", string(tc.Params)))
+    // stash span on AgentCtx state if you need to End() it in OnToolEnd
+    _ = ctx
+})
+```
+
+Note: hooks receive `Ctx` for read access; they don't replace the ctx the
+kernel uses for the LLM call or tool execution. To inject deadlines or values
+into downstream calls, wrap the ctx before passing it to `Run` / `Stream`.
+
 ### Context availability at a glance
 
 ```
 TurnContext (OnStart/OnFinish)
+├─ Ctx       → active context.Context (tracing, cancellation, values)
 ├─ AgentCtx  → modify tools, messages, system prompt
 ├─ Input     → the user's input string
 └─ Result    → nil in OnStart, populated in OnFinish
 
 RoundContext (PrepareRound/OnRoundFinish)
+├─ Ctx          → active context.Context
 ├─ AgentCtx     → modify tools, messages
 ├─ RoundNumber  → which round (0-indexed)
 └─ LastResponse → nil on first round
 
 ToolContext (OnToolStart/OnToolEnd)
+├─ Ctx       → active context.Context
 ├─ ToolName  → which tool
 ├─ Params    → raw JSON params
 ├─ Result    → nil in OnToolStart

--- a/kernel/agent.go
+++ b/kernel/agent.go
@@ -26,6 +26,11 @@ type StopCondition func(ctx *RoundContext) bool
 
 // TurnContext is available to OnStart and OnFinish hooks.
 type TurnContext struct {
+	// Ctx is the active context.Context for the turn — the same ctx passed
+	// to Agent.Run / Agent.Stream. Hooks can use it to create OTel child
+	// spans, observe cancellation (via Ctx.Done / Ctx.Err), or read
+	// request-scoped values set by callers upstream.
+	Ctx      context.Context
 	AgentCtx *AgentContext
 	Input    string
 	Result   *Result
@@ -33,6 +38,8 @@ type TurnContext struct {
 
 // RoundContext is available to PrepareRound, OnRoundFinish, and StopWhen.
 type RoundContext struct {
+	// Ctx is the active context.Context for the round. See TurnContext.Ctx.
+	Ctx          context.Context
 	AgentCtx     *AgentContext
 	RoundNumber  int
 	LastResponse *Response
@@ -40,6 +47,8 @@ type RoundContext struct {
 
 // ToolContext is available to OnToolStart and OnToolEnd hooks.
 type ToolContext struct {
+	// Ctx is the active context.Context for the tool call. See TurnContext.Ctx.
+	Ctx      context.Context
 	ToolName string
 	Params   json.RawMessage
 	Result   any
@@ -147,7 +156,7 @@ func (a *Agent) Run(ctx context.Context, input string) (*Result, error) {
 	}
 	agentCtx.AddMessages(UserMsg(input))
 
-	turnCtx := &TurnContext{AgentCtx: agentCtx, Input: input}
+	turnCtx := &TurnContext{Ctx: ctx, AgentCtx: agentCtx, Input: input}
 
 	// Fire OnStart hooks
 	for _, fn := range a.hooks.onStart {
@@ -162,6 +171,7 @@ func (a *Agent) Run(ctx context.Context, input string) (*Result, error) {
 	// Agent loop
 	for round := 0; round < a.maxRounds; round++ {
 		roundCtx := &RoundContext{
+			Ctx:          ctx,
 			AgentCtx:     agentCtx,
 			RoundNumber:  round,
 			LastResponse: lastResponse,
@@ -317,6 +327,7 @@ func (a *Agent) executeSingleTool(ctx context.Context, agentCtx *AgentContext, c
 	}
 
 	toolCtx := &ToolContext{
+		Ctx:      ctx,
 		ToolName: call.Name,
 		Params:   call.Params,
 	}

--- a/kernel/agent_stream.go
+++ b/kernel/agent_stream.go
@@ -70,7 +70,7 @@ func (a *Agent) runWithEvents(ctx context.Context, input string, sr *StreamResul
 	}
 	agentCtx.AddMessages(UserMsg(input))
 
-	turnCtx := &TurnContext{AgentCtx: agentCtx, Input: input}
+	turnCtx := &TurnContext{Ctx: ctx, AgentCtx: agentCtx, Input: input}
 
 	for _, fn := range a.hooks.onStart {
 		fn(turnCtx)
@@ -83,6 +83,7 @@ func (a *Agent) runWithEvents(ctx context.Context, input string, sr *StreamResul
 
 	for round := 0; round < a.maxRounds; round++ {
 		roundCtx := &RoundContext{
+			Ctx:          ctx,
 			AgentCtx:     agentCtx,
 			RoundNumber:  round,
 			LastResponse: lastResponse,
@@ -226,7 +227,7 @@ func (a *Agent) executeSingleToolWithEvents(ctx context.Context, agentCtx *Agent
 		return ToolCallResult{}, fmt.Errorf("tool %q not found", call.Name)
 	}
 
-	toolCtx := &ToolContext{ToolName: call.Name, Params: call.Params}
+	toolCtx := &ToolContext{Ctx: ctx, ToolName: call.Name, Params: call.Params}
 
 	// Emit event + fire hooks
 	sr.eventCh <- ToolStartEvent{ToolName: call.Name, Params: call.Params}

--- a/kernel/agent_stream_test.go
+++ b/kernel/agent_stream_test.go
@@ -131,3 +131,76 @@ func TestAgentStreamEvents(t *testing.T) {
 		t.Error("expected TextDeltaEvent")
 	}
 }
+
+// TestAgentStreamHookContextsCarryCtx mirrors the non-streaming test: every
+// hook fired during Stream must see a non-nil Ctx that carries the parent
+// values from the ctx passed to Stream.
+func TestAgentStreamHookContextsCarryCtx(t *testing.T) {
+	type ctxKey string
+	const key ctxKey = "trace-id"
+
+	parent := context.WithValue(context.Background(), key, "stream-xyz")
+
+	searchTool := NewTool("search", "Search",
+		func(ctx context.Context, p searchParams) (string, error) { return "found", nil },
+	)
+
+	llm := newFakeLLM(
+		Response{
+			ToolCalls:    []ToolCall{{ID: "c1", Name: "search", Params: json.RawMessage(`{"query":"test","location":"here"}`)}},
+			FinishReason: "tool_calls",
+		},
+		Response{Text: "Done!", FinishReason: "stop"},
+	)
+
+	var (
+		onStartCtx       context.Context
+		onFinishCtx      context.Context
+		prepareRoundCtx  context.Context
+		onRoundFinishCtx context.Context
+		onToolStartCtx   context.Context
+		onToolEndCtx     context.Context
+	)
+
+	agent := NewAgent(
+		WithModel(llm),
+		WithTools(searchTool),
+		OnStart(func(tc *TurnContext) { onStartCtx = tc.Ctx }),
+		OnFinish(func(tc *TurnContext) { onFinishCtx = tc.Ctx }),
+		PrepareRound(func(rc *RoundContext) { prepareRoundCtx = rc.Ctx }),
+		OnRoundFinish(func(rc *RoundContext) { onRoundFinishCtx = rc.Ctx }),
+		OnToolStart(func(tc *ToolContext) { onToolStartCtx = tc.Ctx }),
+		OnToolEnd(func(tc *ToolContext) { onToolEndCtx = tc.Ctx }),
+	)
+
+	sr, err := agent.Stream(parent, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Drain so the goroutine completes.
+	for range sr.Events() {
+	}
+	for range sr.Text() {
+	}
+	_ = sr.Result()
+
+	for _, c := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"OnStart", onStartCtx},
+		{"OnFinish", onFinishCtx},
+		{"PrepareRound", prepareRoundCtx},
+		{"OnRoundFinish", onRoundFinishCtx},
+		{"OnToolStart", onToolStartCtx},
+		{"OnToolEnd", onToolEndCtx},
+	} {
+		if c.ctx == nil {
+			t.Errorf("%s: Ctx was nil; expected populated context", c.name)
+			continue
+		}
+		if got, _ := c.ctx.Value(key).(string); got != "stream-xyz" {
+			t.Errorf("%s: Ctx did not carry parent value; got %q", c.name, got)
+		}
+	}
+}

--- a/kernel/agent_test.go
+++ b/kernel/agent_test.go
@@ -416,3 +416,97 @@ func TestCloneWithDeepCopiesHookSlices(t *testing.T) {
 		t.Error("clone2's hook fired when running clone1 — hook slices share a backing array")
 	}
 }
+
+// TestAgentHookContextsCarryCtx verifies that every hook (OnStart, OnFinish,
+// PrepareRound, OnRoundFinish, OnToolStart, OnToolEnd) receives a non-nil
+// context.Context on its hook context, populated from the ctx passed to Run.
+// This is what lets hooks create OTel child spans, observe ctx cancellation,
+// and read request-scoped values.
+func TestAgentHookContextsCarryCtx(t *testing.T) {
+	type ctxKey string
+	const key ctxKey = "trace-id"
+
+	parent := context.WithValue(context.Background(), key, "abc-123")
+
+	llm := newFakeLLM(
+		Response{
+			ToolCalls:    []ToolCall{{ID: "c1", Name: "search", Params: json.RawMessage(`{"query":"a","location":"b"}`)}},
+			FinishReason: "tool_calls",
+		},
+		Response{Text: "done", FinishReason: "stop"},
+	)
+
+	searchTool := NewTool("search", "Search",
+		func(ctx context.Context, p searchParams) (string, error) { return "ok", nil },
+	)
+
+	var (
+		onStartCtx       context.Context
+		onFinishCtx      context.Context
+		prepareRoundCtx  context.Context
+		onRoundFinishCtx context.Context
+		onToolStartCtx   context.Context
+		onToolEndCtx     context.Context
+	)
+
+	agent := NewAgent(
+		WithModel(llm),
+		WithTools(searchTool),
+		OnStart(func(tc *TurnContext) { onStartCtx = tc.Ctx }),
+		OnFinish(func(tc *TurnContext) { onFinishCtx = tc.Ctx }),
+		PrepareRound(func(rc *RoundContext) { prepareRoundCtx = rc.Ctx }),
+		OnRoundFinish(func(rc *RoundContext) { onRoundFinishCtx = rc.Ctx }),
+		OnToolStart(func(tc *ToolContext) { onToolStartCtx = tc.Ctx }),
+		OnToolEnd(func(tc *ToolContext) { onToolEndCtx = tc.Ctx }),
+	)
+
+	if _, err := agent.Run(parent, "test"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"OnStart", onStartCtx},
+		{"OnFinish", onFinishCtx},
+		{"PrepareRound", prepareRoundCtx},
+		{"OnRoundFinish", onRoundFinishCtx},
+		{"OnToolStart", onToolStartCtx},
+		{"OnToolEnd", onToolEndCtx},
+	} {
+		if c.ctx == nil {
+			t.Errorf("%s: Ctx was nil; expected populated context", c.name)
+			continue
+		}
+		if got, _ := c.ctx.Value(key).(string); got != "abc-123" {
+			t.Errorf("%s: Ctx did not carry parent value; got %q", c.name, got)
+		}
+	}
+}
+
+// TestAgentHookCtxObservesCancellation verifies that a hook can observe
+// cancellation via the ctx supplied to Run. We cancel the parent ctx before
+// running and confirm Ctx.Err() is non-nil from inside OnStart.
+func TestAgentHookCtxObservesCancellation(t *testing.T) {
+	llm := newFakeLLM(Response{Text: "ok", FinishReason: "stop"})
+
+	parent, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before Run so the hook sees it immediately
+
+	var seenErr error
+	agent := NewAgent(
+		WithModel(llm),
+		OnStart(func(tc *TurnContext) {
+			if tc.Ctx != nil {
+				seenErr = tc.Ctx.Err()
+			}
+		}),
+	)
+
+	_, _ = agent.Run(parent, "hi")
+
+	if seenErr == nil {
+		t.Error("expected OnStart to observe ctx cancellation via tc.Ctx.Err()")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `Ctx context.Context` field to `kernel.TurnContext`, `kernel.RoundContext`, and `kernel.ToolContext`. Both `Agent.Run` and `Agent.Stream` populate `Ctx` with the active ctx immediately before firing each hook, so hook code now has access to the request-scoped context for OTel tracing, cancellation observation, and value lookup.

## Changes

- `kernel/agent.go`, `kernel/agent_stream.go`: add `Ctx` field to the three hook context types and populate it at every hook fire site (`OnStart`, `OnFinish`, `PrepareRound`, `OnRoundFinish`, `OnToolStart`, `OnToolEnd`).
- `kernel/agent_test.go`, `kernel/agent_stream_test.go`: new tests verify `Ctx` is non-nil in every hook, carries values from the parent ctx, and lets a hook observe cancellation via `Ctx.Err()`.
- `docs/agents.md`: document the new field on each context type plus a "The `Ctx` field" subsection covering tracing / cancellation / request-scoped values use cases.

Kernel module remains stdlib-only.

## Test plan

- [x] `go test ./kernel/...` passes (new tests included)
- [x] Full workspace `go test` across kernel, plan, middleware, workflow, interfaces, axontest, examples, contrib/mongo, providers/{anthropic,openai,google} all green
- [x] `go build ./...` clean across workspace
- [x] `go vet ./kernel/...` clean

Closes #13