### PR TITLE
interfaces,guards: add ToolGuard, OutputGuard, and guards capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ func main() {
 | **workflow**         | `github.com/axonframework/axon/workflow`         | Compose agents and functions: sequential, parallel, routing, retry loops. |
 | **plan**             | `github.com/axonframework/axon/plan`             | Agent-authored multi-step procedures with auditable progress tracking.    |
 | **axontest**         | `github.com/axonframework/axon/axontest`         | MockLLM, assertion helpers, ScoreCard evaluation, batch testing.          |
-| **interfaces**       | `github.com/axonframework/axon/interfaces`       | HistoryStore, MemoryStore, Guard contracts + in-memory implementations.   |
+| **interfaces**       | `github.com/axonframework/axon/interfaces`       | HistoryStore, MemoryStore, Guard / ToolGuard / OutputGuard contracts + in-memory implementations.   |
+| **guards**           | `github.com/axonframework/axon/guards`           | Capability that wires input, tool-param, and output guards from one config. |
 | **providers/anthropic** | `github.com/axonframework/axon/providers/anthropic` | Anthropic Claude LLM adapter.                                          |
 | **providers/google** | `github.com/axonframework/axon/providers/google` | Google Gemini LLM adapter.                                                |
 | **providers/openai** | `github.com/axonframework/axon/providers/openai` | OpenAI Chat Completions LLM adapter.                                      |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,18 +1,24 @@
 # Interfaces
 
-Axon defines four contracts that separate persistence and safety concerns from
-agent logic: `HistoryStore`, `MemoryStore`, `Guard`, and `Embedder`. Each
-interface lives in `github.com/axonframework/axon/interfaces`. Thread-safe
-in-memory reference implementations are provided in the
+Axon defines six contracts that separate persistence and safety concerns from
+agent logic: `HistoryStore`, `MemoryStore`, `Guard`, `ToolGuard`,
+`OutputGuard`, and `Embedder`. Each interface lives in
+`github.com/axonframework/axon/interfaces`. Thread-safe in-memory reference
+implementations are provided in the
 `github.com/axonframework/axon/interfaces/inmemory` package for development and
 testing. Bring your own implementations for production.
+
+The three guard interfaces (`Guard`, `ToolGuard`, `OutputGuard`) cover the three
+points an agent can be intercepted: at input time, before each tool call, and
+on the final response. The `guards/` capability package wires all three from a
+single configuration — see [§ 3.4 Guards capability](#34-guards-capability--wiring-all-three) for the recommended pattern.
 
 ---
 
 ## Hook integration overview
 
 The diagram below shows how stores and guards plug into the agent lifecycle via
-`OnStart` and `OnFinish` hooks.
+`OnStart`, `OnToolStart`, and `OnFinish` hooks.
 
 ```
 agent.Run(ctx, "user input")
@@ -23,9 +29,13 @@ agent.Run(ctx, "user input")
 │  └─ MemoryStore.Search(userID, input) ──► inject as system message
 │
 ├─ Agent loop (rounds)
-│  └─ ... LLM generates, tools execute ...
+│  ├─ LLM generates ──► tool calls
+│  └─ For each tool call:
+│     └─ ToolGuard.Check(name, params) ──► blocked? → tool error to LLM
+│        (loop continues; model can adjust on next round)
 │
 └─ OnFinish
+   ├─ OutputGuard.Check(text) ──► blocked? → replace Result.Text, set state flag
    ├─ HistoryStore.SaveMessages(sessionID, newMessages)
    └─ MemoryStore.Save(userID, extractedMemories)  ← async/optional
 ```
@@ -194,85 +204,130 @@ for _, m := range results {
 
 ---
 
-## 3. Guard
+## 3. Guard, ToolGuard, OutputGuard
 
-`Guard` validates user input before it reaches the agent. Returning
-`Allowed: false` lets the caller intercept the request and return a refusal
-without invoking the model.
+Axon exposes three guard interfaces — one per interception point in the agent
+lifecycle. They share a single `GuardResult` shape:
 
 ```go
-type Guard interface {
-    Check(ctx context.Context, input string) (GuardResult, error)
-}
-
 type GuardResult struct {
     Allowed bool   `json:"allowed"`
     Reason  string `json:"reason,omitempty"`
 }
 ```
 
-### NewBlocklistGuard
+### 3.1 Guard — input validation
 
-`NewBlocklistGuard` creates a `Guard` that rejects input containing any of the
-provided phrases. Matching is case-insensitive substring matching. When
-multiple phrases match, the one at the earliest position in the input causes
-rejection.
+`Guard` validates the user input before the model sees it.
+
+```go
+type Guard interface {
+    Check(ctx context.Context, input string) (GuardResult, error)
+}
+```
+
+`NewBlocklistGuard(blocked []string) Guard` rejects input containing any of the
+given phrases (case-insensitive substring match; earliest match wins).
 
 ```go
 guard := interfaces.NewBlocklistGuard([]string{
     "ignore previous instructions",
     "jailbreak",
-    "forget your instructions",
 })
-
-result, err := guard.Check(ctx, userInput)
-if err != nil {
-    // handle error
-}
-if !result.Allowed {
-    fmt.Println("blocked:", result.Reason)
-}
 ```
 
-### Check flow
+### 3.2 ToolGuard — tool-call validation
 
-```
-Guard.Check(ctx, "user input")
-│
-├─ Allowed: true  ──► agent proceeds normally
-│                      (all tools available, normal prompt)
-│
-└─ Allowed: false ──► OnStart hook reacts:
-   Reason: "blocked"   ├─ AgentCtx.DisableTools()
-                        ├─ AgentCtx.SetSystemPrompt("I can't help with that.")
-                        └─ Agent responds with safety message
-```
-
-### Integration pattern: OnStart hook
-
-Wire the guard into an agent's `OnStart` hook. If the input is blocked, disable
-tools so the model cannot take actions, and return early. The agent will still
-respond, but without tool access.
+`ToolGuard` validates a tool invocation immediately before the underlying tool
+runs. It receives the tool name and the raw JSON params produced by the LLM.
 
 ```go
-kernel.OnStart(func(tc *kernel.TurnContext) {
-    result, err := guard.Check(context.Background(), tc.Input)
-    if err != nil {
-        logger.Error("guard check error", "error", err)
-        return
-    }
-    if !result.Allowed {
-        logger.Warn("input blocked by guard", "reason", result.Reason)
-        tc.AgentCtx.DisableTools("search_restaurants", "make_reservation")
-        return
-    }
-
-    // Guard passed — continue with history loading or other setup.
-}),
+type ToolGuard interface {
+    Check(ctx context.Context, toolName string, params json.RawMessage) (GuardResult, error)
+}
 ```
 
-The restaurant bot (`examples/07-restaurant-bot/agent.go`) demonstrates this
-combined guard-then-history pattern in a single `OnStart` hook.
+`NewSimpleToolGuard(blockedTools []string) ToolGuard` blocks any tool whose
+exact name is in the blocklist. (Tool names are case-sensitive identifiers, so
+the comparison is exact-match — unlike the input/output blocklists which match
+natural-language phrases case-insensitively.)
+
+```go
+toolGuard := interfaces.NewSimpleToolGuard([]string{
+    "shell_exec", "delete_file",
+})
+```
+
+When a tool call is rejected, the underlying tool does **not** execute. The
+guard wrapper returns an error to the kernel, which surfaces it to the LLM as a
+tool-error message. The agent loop **continues** — the model can adjust and
+try a different action on the next round.
+
+### 3.3 OutputGuard — response validation
+
+`OutputGuard` validates the agent's final response text after the loop ends
+but before the result is returned to the caller.
+
+```go
+type OutputGuard interface {
+    Check(ctx context.Context, output string) (GuardResult, error)
+}
+```
+
+`NewSimpleOutputGuard(blocked []string) OutputGuard` rejects any final
+response containing one of the given phrases (case-insensitive substring
+match, mirroring `NewBlocklistGuard`).
+
+```go
+outputGuard := interfaces.NewSimpleOutputGuard([]string{
+    "social security number", "credit card",
+})
+```
+
+When the output is rejected, `Result.Text` is replaced with
+`"[blocked: <reason>]"` and a flag is recorded in `AgentContext.State` under
+`guards.StateOutputBlockedKey`. The `Run` does **not** return an error.
+
+### 3.4 Guards capability — wiring all three
+
+The `github.com/axonframework/axon/guards` package wires the three axes from a
+single configuration. Spread `Enable`'s result into `kernel.NewAgent`:
+
+```go
+import "github.com/axonframework/axon/guards"
+
+agent := kernel.NewAgent(append(baseOpts, guards.Enable(
+    guards.WithInput(interfaces.NewBlocklistGuard([]string{"jailbreak"})),
+    guards.WithTool(interfaces.NewSimpleToolGuard([]string{"shell_exec"})),
+    guards.WithOutput(interfaces.NewSimpleOutputGuard([]string{"ssn"})),
+)...)...)
+```
+
+`Enable` accepts any subset of the three options; passing zero options is a
+no-op. Each option installs the matching hook(s):
+
+| Option        | Hook used        | Rejection behavior                                                                                                  |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `WithInput`   | `OnStart`        | Disables every registered tool for the turn so the model responds without tool access                              |
+| `WithTool`    | `OnStart` + tool wrapper | Wraps each tool's `Execute`; on rejection returns a tool error to the LLM and lets the agent loop continue   |
+| `WithOutput`  | `OnFinish`       | Replaces `Result.Text` with `[blocked: <reason>]` and sets `AgentContext.State[guards.StateOutputBlockedKey] = true` |
+
+Detecting an output rejection from caller code:
+
+```go
+result, _ := agent.Run(ctx, input)
+// Run does not error on output rejection. Inspect via Result.Text prefix or
+// (when you need the structured signal) via AgentContext state — see the
+// guards package docs for accessing State outside of a hook.
+```
+
+### Choosing between hand-rolled hooks and the guards capability
+
+The restaurant bot (`examples/07-restaurant-bot/agent.go`) shows a hand-rolled
+`OnStart` that combines a guard check with history loading. That pattern is
+still useful when you need custom rejection logic (e.g. set a refusal system
+prompt). Use `guards.Enable` when standard rejection behavior is sufficient
+and you want declarative composition of all three axes.
 
 ---
 

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.26.2
 use (
 	./contrib/mongo
 	./examples
+	./guards
 	./interfaces
 	./kernel
 	./middleware

--- a/guards/go.mod
+++ b/guards/go.mod
@@ -1,0 +1,15 @@
+module github.com/axonframework/axon/guards
+
+go 1.26.2
+
+require (
+	github.com/axonframework/axon/axontest v0.0.0
+	github.com/axonframework/axon/interfaces v0.0.0
+	github.com/axonframework/axon/kernel v0.0.0
+)
+
+replace github.com/axonframework/axon/kernel => ../kernel
+
+replace github.com/axonframework/axon/interfaces => ../interfaces
+
+replace github.com/axonframework/axon/axontest => ../axontest

--- a/guards/guards.go
+++ b/guards/guards.go
@@ -1,0 +1,191 @@
+// Package guards wires the three axes of agent safety — input, tool-parameter,
+// and output — into a single capability. Spread Enable's result into NewAgent:
+//
+//	agent := kernel.NewAgent(append(baseOpts, guards.Enable(
+//	    guards.WithInput(blocklist),
+//	    guards.WithTool(toolPolicy),
+//	    guards.WithOutput(piiRedactor),
+//	)...)...)
+//
+// # Rejection behaviors
+//
+// Each axis has a clear, documented rejection behavior:
+//
+//   - Input guard (interfaces.Guard, OnStart): when an input is rejected, all
+//     tools registered on the agent are disabled for the turn so the model
+//     responds without taking any action. This mirrors the existing pattern in
+//     examples/07-restaurant-bot. The agent still produces a (refusal) response.
+//
+//   - Tool-param guard (interfaces.ToolGuard, OnStart wraps tools): when a
+//     pending tool call is rejected, the underlying tool is NOT executed.
+//     Instead the wrapper returns an error containing the guard's Reason. The
+//     kernel surfaces that error to the LLM as a tool-error message and the
+//     agent loop continues — the model can then adjust its behavior on the
+//     next round. (Option A from issue #17: continue the loop with a tool
+//     error, not abort the whole Run.)
+//
+//   - Output guard (interfaces.OutputGuard, OnFinish): when the final response
+//     is rejected, the agent's Result.Text is replaced with a sanitized message
+//     ("[blocked: <reason>]") and the OutputBlocked flag is stashed in
+//     AgentContext.State under StateOutputBlockedKey. The Run does NOT error;
+//     callers can detect the rejection via state inspection or by recognizing
+//     the [blocked:] prefix.
+package guards
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/axonframework/axon/interfaces"
+	"github.com/axonframework/axon/kernel"
+)
+
+// StateOutputBlockedKey is the AgentContext.State key set to true when the
+// output guard rejected the final response. Callers can read
+// agentCtx.State[guards.StateOutputBlockedKey] after Run to detect rejection.
+const StateOutputBlockedKey = "guards.output_blocked"
+
+// StateOutputBlockReasonKey is the AgentContext.State key holding the reason
+// string from the output guard when StateOutputBlockedKey is true.
+const StateOutputBlockReasonKey = "guards.output_block_reason"
+
+// config aggregates the optional guards for a single Enable call.
+type config struct {
+	input  interfaces.Guard
+	tool   interfaces.ToolGuard
+	output interfaces.OutputGuard
+}
+
+// Option configures Enable.
+type Option func(*config)
+
+// WithInput attaches an input guard. Fired in OnStart; if rejected, all tools
+// are disabled for the turn.
+func WithInput(g interfaces.Guard) Option {
+	return func(c *config) { c.input = g }
+}
+
+// WithTool attaches a tool-parameter guard. Each registered tool is wrapped so
+// its Execute first calls the guard. Rejected calls return an error to the LLM
+// (the agent loop continues).
+func WithTool(g interfaces.ToolGuard) Option {
+	return func(c *config) { c.tool = g }
+}
+
+// WithOutput attaches an output guard. Fired in OnFinish; if rejected, the
+// final Result.Text is replaced with a sanitized message and a flag is set in
+// AgentContext.State.
+func WithOutput(g interfaces.OutputGuard) Option {
+	return func(c *config) { c.output = g }
+}
+
+// Enable returns AgentOptions wiring the configured guards. Spread into
+// kernel.NewAgent. Passing zero guards is valid and returns an empty slice.
+func Enable(opts ...Option) []kernel.AgentOption {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	var agentOpts []kernel.AgentOption
+
+	if cfg.input != nil {
+		agentOpts = append(agentOpts, kernel.OnStart(func(tc *kernel.TurnContext) {
+			result, err := cfg.input.Check(context.Background(), tc.Input)
+			if err != nil {
+				// Guard internal error: fail-closed by disabling tools, but do
+				// not crash the agent. The model still produces a response.
+				disableAllTools(tc.AgentCtx)
+				return
+			}
+			if !result.Allowed {
+				disableAllTools(tc.AgentCtx)
+			}
+		}))
+	}
+
+	if cfg.tool != nil {
+		// Wrap registered tools at OnStart so guard runs before Execute.
+		// Doing this in OnStart (rather than at construction time) lets the
+		// wrapper see tools added by other capabilities (plan, etc.) that also
+		// register their tools in OnStart, as long as guards.Enable is the LAST
+		// option in the list. For tools registered earlier (e.g. via WithTools)
+		// this still works because by OnStart time they're all in AgentCtx.
+		guard := cfg.tool
+		agentOpts = append(agentOpts, kernel.OnStart(func(tc *kernel.TurnContext) {
+			all := tc.AgentCtx.AllTools()
+			wrapped := make([]kernel.Tool, len(all))
+			for i, t := range all {
+				wrapped[i] = &guardedTool{inner: t, guard: guard}
+			}
+			tc.AgentCtx.ReplaceTools(wrapped)
+		}))
+	}
+
+	if cfg.output != nil {
+		guard := cfg.output
+		agentOpts = append(agentOpts, kernel.OnFinish(func(tc *kernel.TurnContext) {
+			if tc.Result == nil {
+				return
+			}
+			res, err := guard.Check(context.Background(), tc.Result.Text)
+			if err != nil {
+				// Fail-closed: replace the text with a generic block notice.
+				tc.Result.Text = fmt.Sprintf("[blocked: output guard error: %v]", err)
+				if tc.AgentCtx.State == nil {
+					tc.AgentCtx.State = make(map[string]any)
+				}
+				tc.AgentCtx.State[StateOutputBlockedKey] = true
+				tc.AgentCtx.State[StateOutputBlockReasonKey] = err.Error()
+				return
+			}
+			if !res.Allowed {
+				tc.Result.Text = fmt.Sprintf("[blocked: %s]", res.Reason)
+				if tc.AgentCtx.State == nil {
+					tc.AgentCtx.State = make(map[string]any)
+				}
+				tc.AgentCtx.State[StateOutputBlockedKey] = true
+				tc.AgentCtx.State[StateOutputBlockReasonKey] = res.Reason
+			}
+		}))
+	}
+
+	return agentOpts
+}
+
+// disableAllTools turns off every tool currently registered on the context.
+// Used when the input guard rejects a turn.
+func disableAllTools(ac *kernel.AgentContext) {
+	names := make([]string, 0, len(ac.AllTools()))
+	for _, t := range ac.AllTools() {
+		names = append(names, t.Name())
+	}
+	if len(names) > 0 {
+		ac.DisableTools(names...)
+	}
+}
+
+// guardedTool wraps an inner Tool so that Execute first consults the ToolGuard.
+// On rejection, Execute returns an error whose message is the guard Reason; the
+// kernel converts this into a tool-error message back to the LLM, allowing the
+// agent loop to continue.
+type guardedTool struct {
+	inner kernel.Tool
+	guard interfaces.ToolGuard
+}
+
+func (g *guardedTool) Name() string          { return g.inner.Name() }
+func (g *guardedTool) Description() string   { return g.inner.Description() }
+func (g *guardedTool) Schema() kernel.Schema { return g.inner.Schema() }
+
+func (g *guardedTool) Execute(ctx context.Context, params json.RawMessage) (any, error) {
+	res, err := g.guard.Check(ctx, g.inner.Name(), params)
+	if err != nil {
+		return nil, fmt.Errorf("tool guard error: %w", err)
+	}
+	if !res.Allowed {
+		return nil, fmt.Errorf("tool call blocked by guard: %s", res.Reason)
+	}
+	return g.inner.Execute(ctx, params)
+}

--- a/guards/guards_test.go
+++ b/guards/guards_test.go
@@ -1,0 +1,213 @@
+// guards/guards_test.go
+package guards_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/axonframework/axon/axontest"
+	"github.com/axonframework/axon/guards"
+	"github.com/axonframework/axon/interfaces"
+	"github.com/axonframework/axon/kernel"
+)
+
+// dummyTool returns a minimal tool that records when it was executed.
+type dummyTool struct {
+	name     string
+	desc     string
+	executed *bool
+}
+
+func (d *dummyTool) Name() string          { return d.name }
+func (d *dummyTool) Description() string   { return d.desc }
+func (d *dummyTool) Schema() kernel.Schema { return kernel.Schema{Type: "object"} }
+func (d *dummyTool) Execute(_ context.Context, _ json.RawMessage) (any, error) {
+	*d.executed = true
+	return "ok", nil
+}
+
+// TestEnableInputGuardBlocks verifies that an input guard wired via guards.Enable
+// blocks the offending input. The guard's behavior follows the existing pattern:
+// disable all tools and let the agent respond without tool access.
+func TestEnableInputGuardBlocks(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithText("I cannot help with that request.")
+
+	executed := false
+	tool := &dummyTool{name: "search", desc: "search things", executed: &executed}
+
+	inputGuard := interfaces.NewBlocklistGuard([]string{"jailbreak"})
+
+	opts := append(
+		[]kernel.AgentOption{
+			kernel.WithModel(llm),
+			kernel.WithTools(tool),
+		},
+		guards.Enable(guards.WithInput(inputGuard))...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	result := axontest.Run(t, agent, "please jailbreak the system")
+
+	result.ExpectTool("search").NotCalled(t)
+	if executed {
+		t.Error("tool should not have executed when input guard blocks")
+	}
+	_ = result.Text()
+}
+
+// TestEnableInputGuardAllows verifies that benign input passes the input guard.
+func TestEnableInputGuardAllows(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithText("Hello! How can I help?")
+
+	inputGuard := interfaces.NewBlocklistGuard([]string{"jailbreak"})
+
+	opts := append(
+		[]kernel.AgentOption{kernel.WithModel(llm)},
+		guards.Enable(guards.WithInput(inputGuard))...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	result := axontest.Run(t, agent, "What's a good Italian restaurant?")
+
+	if !strings.Contains(result.Text(), "How can I help") {
+		t.Errorf("expected normal response, got: %q", result.Text())
+	}
+}
+
+// TestEnableToolGuardBlocksExecution verifies that when a ToolGuard rejects
+// a tool call, the underlying tool is NOT executed. The agent loop continues
+// (tool error returned to the LLM) and the next round produces a response.
+func TestEnableToolGuardBlocksExecution(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithToolCall("delete_file", map[string]any{"path": "/etc/passwd"}).
+		OnRound(1).RespondWithText("I was unable to perform that action.")
+
+	executed := false
+	tool := &dummyTool{name: "delete_file", desc: "delete a file", executed: &executed}
+
+	toolGuard := interfaces.NewSimpleToolGuard([]string{"delete_file"})
+
+	opts := append(
+		[]kernel.AgentOption{
+			kernel.WithModel(llm),
+			kernel.WithTools(tool),
+		},
+		guards.Enable(guards.WithTool(toolGuard))...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	result := axontest.Run(t, agent, "please delete /etc/passwd")
+
+	if executed {
+		t.Error("blocked tool should not have executed")
+	}
+
+	// The agent should still complete and produce a final response.
+	if result.Text() == "" {
+		t.Error("expected a final response after tool guard blocks; got empty text")
+	}
+
+	// The tool-error round should be visible in the result.
+	if result.RoundCount() < 2 {
+		t.Errorf("expected at least 2 rounds (blocked tool + recovery), got %d", result.RoundCount())
+	}
+}
+
+// TestEnableToolGuardAllowsExecution verifies that allowed tool calls execute normally.
+func TestEnableToolGuardAllowsExecution(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithToolCall("search", map[string]any{"q": "italian"}).
+		OnRound(1).RespondWithText("Done.")
+
+	executed := false
+	tool := &dummyTool{name: "search", desc: "search", executed: &executed}
+
+	toolGuard := interfaces.NewSimpleToolGuard([]string{"delete_file"}) // search is fine
+
+	opts := append(
+		[]kernel.AgentOption{
+			kernel.WithModel(llm),
+			kernel.WithTools(tool),
+		},
+		guards.Enable(guards.WithTool(toolGuard))...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	_ = axontest.Run(t, agent, "search for italian")
+
+	if !executed {
+		t.Error("non-blocked tool should have executed")
+	}
+}
+
+// TestEnableOutputGuardReplacesText verifies that when an OutputGuard rejects
+// the final response, Result.Text is replaced with the guard's reason and
+// Result.Blocked indicates the rejection.
+func TestEnableOutputGuardReplacesText(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithText("Your social security number is 123-45-6789.")
+
+	outputGuard := interfaces.NewSimpleOutputGuard([]string{"social security number"})
+
+	opts := append(
+		[]kernel.AgentOption{kernel.WithModel(llm)},
+		guards.Enable(guards.WithOutput(outputGuard))...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	result := axontest.Run(t, agent, "What's my SSN?")
+
+	if strings.Contains(result.Text(), "123-45-6789") {
+		t.Errorf("output guard failed to redact SSN; got: %q", result.Text())
+	}
+	if !strings.Contains(strings.ToLower(result.Text()), "social security number") &&
+		!strings.Contains(strings.ToLower(result.Text()), "blocked") {
+		t.Errorf("expected reason or block notice in output, got: %q", result.Text())
+	}
+}
+
+// TestEnableOutputGuardAllowsText verifies that benign output passes through unchanged.
+func TestEnableOutputGuardAllowsText(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithText("Bella Trattoria is a great choice!")
+
+	outputGuard := interfaces.NewSimpleOutputGuard([]string{"social security number"})
+
+	opts := append(
+		[]kernel.AgentOption{kernel.WithModel(llm)},
+		guards.Enable(guards.WithOutput(outputGuard))...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	result := axontest.Run(t, agent, "Recommend a restaurant")
+
+	if !strings.Contains(result.Text(), "Bella Trattoria") {
+		t.Errorf("expected unmodified output, got: %q", result.Text())
+	}
+}
+
+// TestEnableAllThree composes all three guard axes and verifies they coexist.
+func TestEnableAllThree(t *testing.T) {
+	llm := axontest.NewMockLLM().
+		OnRound(0).RespondWithText("All good.")
+
+	opts := append(
+		[]kernel.AgentOption{kernel.WithModel(llm)},
+		guards.Enable(
+			guards.WithInput(interfaces.NewBlocklistGuard([]string{"jailbreak"})),
+			guards.WithTool(interfaces.NewSimpleToolGuard([]string{"shell"})),
+			guards.WithOutput(interfaces.NewSimpleOutputGuard([]string{"secret"})),
+		)...,
+	)
+
+	agent := kernel.NewAgent(opts...)
+	result := axontest.Run(t, agent, "Hello there")
+
+	if result.Text() != "All good." {
+		t.Errorf("expected unmodified response, got: %q", result.Text())
+	}
+}

--- a/interfaces/output_guard.go
+++ b/interfaces/output_guard.go
@@ -1,0 +1,58 @@
+// interfaces/output_guard.go
+package interfaces
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// OutputGuard validates the agent's final response text after the agent loop
+// completes but before the result is returned to the caller. Returning
+// Allowed=false signals that the output should be sanitized, replaced, or
+// rejected. The exact rejection behavior is defined by the consumer (typically
+// the guards capability package).
+type OutputGuard interface {
+	// Check evaluates the final response text and returns whether it is allowed.
+	Check(ctx context.Context, output string) (GuardResult, error)
+}
+
+// simpleOutputGuard rejects output that contains any of the configured phrases.
+// Mirrors NewBlocklistGuard, but operates on the agent's final response text.
+type simpleOutputGuard struct {
+	blocked []string // stored as lowercase
+}
+
+// NewSimpleOutputGuard creates an OutputGuard that rejects any final response
+// containing one of the given phrases. Matching is case-insensitive substring
+// matching. The earliest-matching phrase wins.
+func NewSimpleOutputGuard(blocked []string) OutputGuard {
+	lower := make([]string, len(blocked))
+	for i, b := range blocked {
+		lower[i] = strings.ToLower(b)
+	}
+	return &simpleOutputGuard{blocked: lower}
+}
+
+// Check scans the output for any blocked phrase. The match with the earliest
+// position in the output causes rejection. Returns Allowed=true when no phrase
+// matches.
+func (g *simpleOutputGuard) Check(_ context.Context, output string) (GuardResult, error) {
+	lowered := strings.ToLower(output)
+	bestIdx := -1
+	bestPhrase := ""
+	for _, phrase := range g.blocked {
+		idx := strings.Index(lowered, phrase)
+		if idx >= 0 && (bestIdx < 0 || idx < bestIdx) {
+			bestIdx = idx
+			bestPhrase = phrase
+		}
+	}
+	if bestIdx >= 0 {
+		return GuardResult{
+			Allowed: false,
+			Reason:  fmt.Sprintf("output contains blocked phrase: %q", bestPhrase),
+		}, nil
+	}
+	return GuardResult{Allowed: true}, nil
+}

--- a/interfaces/output_guard_test.go
+++ b/interfaces/output_guard_test.go
@@ -1,0 +1,76 @@
+// interfaces/output_guard_test.go
+package interfaces
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSimpleOutputGuardAllowed(t *testing.T) {
+	guard := NewSimpleOutputGuard([]string{"social security number", "credit card"})
+
+	result, err := guard.Check(context.Background(), "Here is your restaurant recommendation: Bella Trattoria.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Errorf("expected allowed, got blocked with reason: %s", result.Reason)
+	}
+	if result.Reason != "" {
+		t.Errorf("expected empty reason, got %q", result.Reason)
+	}
+}
+
+func TestSimpleOutputGuardBlocked(t *testing.T) {
+	guard := NewSimpleOutputGuard([]string{"social security number", "credit card"})
+
+	result, err := guard.Check(context.Background(), "Your social security number is 123-45-6789")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Allowed {
+		t.Error("expected blocked, got allowed")
+	}
+	if result.Reason != `output contains blocked phrase: "social security number"` {
+		t.Errorf("unexpected reason: %q", result.Reason)
+	}
+}
+
+func TestSimpleOutputGuardCaseInsensitive(t *testing.T) {
+	guard := NewSimpleOutputGuard([]string{"top secret"})
+
+	result, err := guard.Check(context.Background(), "This is TOP SECRET information.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Allowed {
+		t.Error("expected blocked for uppercase output, got allowed")
+	}
+}
+
+func TestSimpleOutputGuardEmptyBlocklist(t *testing.T) {
+	guard := NewSimpleOutputGuard(nil)
+
+	result, err := guard.Check(context.Background(), "anything goes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected allowed with empty blocklist, got blocked")
+	}
+}
+
+func TestSimpleOutputGuardEmptyOutput(t *testing.T) {
+	guard := NewSimpleOutputGuard([]string{"bad"})
+
+	result, err := guard.Check(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected allowed for empty output, got blocked")
+	}
+}
+
+// OutputGuard interface conformance check at compile time.
+var _ OutputGuard = (*simpleOutputGuard)(nil)

--- a/interfaces/tool_guard.go
+++ b/interfaces/tool_guard.go
@@ -1,0 +1,49 @@
+// interfaces/tool_guard.go
+package interfaces
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ToolGuard validates a tool invocation before the underlying tool executes.
+// It receives the tool name and the raw JSON parameters the LLM produced.
+// Returning Allowed=false instructs the consumer to skip execution; the exact
+// rejection behavior (e.g. report a tool error back to the LLM) is defined by
+// the consumer (typically the guards capability package).
+type ToolGuard interface {
+	// Check evaluates a pending tool invocation and returns whether it is allowed.
+	Check(ctx context.Context, toolName string, params json.RawMessage) (GuardResult, error)
+}
+
+// simpleToolGuard rejects tool calls whose name appears in the blocklist.
+// Tool name comparison is case-sensitive because tool names are exact-match
+// identifiers in the agent's tool registry.
+type simpleToolGuard struct {
+	blocked map[string]struct{}
+}
+
+// NewSimpleToolGuard creates a ToolGuard that rejects any tool whose name
+// appears in the given list. Comparison is case-sensitive (tool names are
+// identifiers, not natural language).
+func NewSimpleToolGuard(blocked []string) ToolGuard {
+	set := make(map[string]struct{}, len(blocked))
+	for _, name := range blocked {
+		set[name] = struct{}{}
+	}
+	return &simpleToolGuard{blocked: set}
+}
+
+// Check returns Allowed=false if toolName is in the configured blocklist.
+// Params are accepted for interface symmetry but ignored by this simple
+// implementation; richer guards may inspect them.
+func (g *simpleToolGuard) Check(_ context.Context, toolName string, _ json.RawMessage) (GuardResult, error) {
+	if _, ok := g.blocked[toolName]; ok {
+		return GuardResult{
+			Allowed: false,
+			Reason:  fmt.Sprintf("tool %q is blocked", toolName),
+		}, nil
+	}
+	return GuardResult{Allowed: true}, nil
+}

--- a/interfaces/tool_guard_test.go
+++ b/interfaces/tool_guard_test.go
@@ -1,0 +1,67 @@
+// interfaces/tool_guard_test.go
+package interfaces
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestSimpleToolGuardAllowed(t *testing.T) {
+	guard := NewSimpleToolGuard([]string{"shell_exec", "delete_file"})
+
+	result, err := guard.Check(context.Background(), "search_restaurants", json.RawMessage(`{"query":"italian"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Errorf("expected allowed, got blocked with reason: %s", result.Reason)
+	}
+	if result.Reason != "" {
+		t.Errorf("expected empty reason, got %q", result.Reason)
+	}
+}
+
+func TestSimpleToolGuardBlocked(t *testing.T) {
+	guard := NewSimpleToolGuard([]string{"shell_exec", "delete_file"})
+
+	result, err := guard.Check(context.Background(), "shell_exec", json.RawMessage(`{"cmd":"rm -rf /"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Allowed {
+		t.Error("expected blocked, got allowed")
+	}
+	if result.Reason != `tool "shell_exec" is blocked` {
+		t.Errorf("unexpected reason: %q", result.Reason)
+	}
+}
+
+func TestSimpleToolGuardCaseSensitive(t *testing.T) {
+	// Tool names are case-sensitive identifiers in code, so the guard must
+	// match exactly. "Shell_Exec" should NOT match "shell_exec".
+	guard := NewSimpleToolGuard([]string{"shell_exec"})
+
+	result, err := guard.Check(context.Background(), "Shell_Exec", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected allowed for differently-cased tool name, got blocked")
+	}
+}
+
+func TestSimpleToolGuardEmptyBlocklist(t *testing.T) {
+	guard := NewSimpleToolGuard(nil)
+
+	result, err := guard.Check(context.Background(), "any_tool", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected allowed with empty blocklist, got blocked")
+	}
+}
+
+// ToolGuard interface conformance check at compile time.
+var _ ToolGuard = (*simpleToolGuard)(nil)


### PR DESCRIPTION
## Summary

Extends the safety model from a single input `Guard` to three axes that match the agent lifecycle:

- `Guard` (existing) — input validation in `OnStart`
- `ToolGuard` (new) — tool-param validation immediately before each tool call
- `OutputGuard` (new) — final-response validation in `OnFinish`

A new `guards/` module (own Go module, added to `go.work`) wires all three from one config:

```go
agent := kernel.NewAgent(append(baseOpts, guards.Enable(
    guards.WithInput(interfaces.NewBlocklistGuard([]string{"jailbreak"})),
    guards.WithTool(interfaces.NewSimpleToolGuard([]string{"shell_exec"})),
    guards.WithOutput(interfaces.NewSimpleOutputGuard([]string{"ssn"})),
)...)...)
```

## Rejection behaviors (chosen and documented)

- **Tool-param guard — Option A from the issue.** Each registered tool is wrapped at `OnStart`. When the guard rejects, the wrapper returns an error to the kernel which surfaces it to the LLM as a tool-error message; the agent loop continues so the model can adjust on the next round. `Run` does not error out.
- **Output guard.** When rejected, `Result.Text` is replaced with `"[blocked: <reason>]"` and a flag is set in `AgentContext.State[guards.StateOutputBlockedKey]`. `Run` does not error out.

Both behaviors are documented in the package-level comment on `guards/guards.go` and in `docs/interfaces.md`.

## Public API

- `interfaces.OutputGuard` — `Check(ctx, output) (GuardResult, error)`
- `interfaces.ToolGuard` — `Check(ctx, toolName, params) (GuardResult, error)`
- `interfaces.NewSimpleOutputGuard(blocked []string) OutputGuard`
- `interfaces.NewSimpleToolGuard(blockedTools []string) ToolGuard`
- `guards.Enable(opts ...Option) []kernel.AgentOption`
- `guards.WithInput`, `guards.WithTool`, `guards.WithOutput`
- `guards.StateOutputBlockedKey`, `guards.StateOutputBlockReasonKey`

The existing `interfaces.Guard` is unchanged — backward compatible.

## Test plan

- [x] `interfaces` — new tests for `NewSimpleOutputGuard` and `NewSimpleToolGuard` (allowed / blocked / case sensitivity / empty list / empty input)
- [x] `guards` — `Enable` capability tested with axontest.MockLLM driving the agent through input-guard, tool-guard, and output-guard scenarios; `TestEnableAllThree` composes all three
- [x] `go test ./...` green across every module (`interfaces`, `kernel`, `axontest`, `middleware`, `plan`, `workflow`, `examples`, `guards`, all providers, `contrib/mongo`)
- [x] `go vet ./...` clean across every module

Closes #17